### PR TITLE
Revert "Cache pip dependencies"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,13 +23,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          # This path is ubuntu specific
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
-          restore-keys: ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Reverts allaffa/GCNN#12

@streeve I merged the pull request. Then I did 'git rebase multitask', so that the changes in the multitask branch created by Pei would keep track of yours. 

I pushed again the rebased multitask branch, and noticed that the CI still takes several minutes. I am reverting the merge request so that we keep track of something that we need to fix. 

We can talk about this on Tuesday. 