### PR TITLE
Cache virtual environment instead of pip

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,24 +28,27 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libopenmpi-dev
           sudo apt-get clean
-      - name: Cache pip
+      - name: Cache venv
         uses: actions/cache@v2
         with:
-          # This path is ubuntu specific
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
-          restore-keys: ${{ runner.os }}-pip-
+          path: ~/.venv
+          key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: ${{ runner.os }}-venv-
       - name: Install dependencies
         run: |
+          python -m venv ~/.venv
+          ~/.venv/bin/activate
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
           pip install -r requirements-torchdep.txt
       - name: Run pytest
         run: |
+          ~/.venv/bin/activate
           pytest
           mpirun -n 1 python -m pytest --with-mpi
           mpirun -n 2 python -m pytest --with-mpi
       - name: Format black
         run: |
+          ~/.venv/bin/activate
           black .
           git diff --exit-code


### PR DESCRIPTION
Part of #19 

Purposely not using the cache once created (done in #17) to make sure we don't merge a broken cache into main 