### PR TITLE
Updates for using multi-nodes on Summit

### DIFF
--- a/run_config_input.py
+++ b/run_config_input.py
@@ -8,6 +8,7 @@ from utils.utils import (
     dataset_loading_and_splitting,
     train_validate_test_normal,
     setup_ddp,
+    get_comm_size_and_rank,
 )
 from utils.models_setup import generate_model, get_device
 from data_utils.dataset_descriptors import (
@@ -313,7 +314,7 @@ def run_normal_config_file(config_file="./examples/configuration.json"):
     )
     save_state = False
     if isinstance(model, torch.nn.parallel.distributed.DistributedDataParallel):
-        world_rank = os.environ["OMPI_COMM_WORLD_RANK"]
+        _, world_rank = get_comm_size_and_rank
         if int(world_rank) == 0:
             save_state = True
     else:

--- a/run_config_input.py
+++ b/run_config_input.py
@@ -314,7 +314,7 @@ def run_normal_config_file(config_file="./examples/configuration.json"):
     )
     save_state = False
     if isinstance(model, torch.nn.parallel.distributed.DistributedDataParallel):
-        _, world_rank = get_comm_size_and_rank
+        _, world_rank = get_comm_size_and_rank()
         if int(world_rank) == 0:
             save_state = True
     else:

--- a/utils/models_setup.py
+++ b/utils/models_setup.py
@@ -30,9 +30,16 @@ def get_device(use_gpu=True, rank_per_model=1):
         raise ValueError("Exactly 1 rank per device currently supported")
 
     print("Using GPU")
-    ## We try not to specify GPU IDs to be more flexible
-    #device_name = "cuda:" + str(world_rank)
-    device_name = "cuda"
+    ## We need to ge a local rank to assign one of GPUs per node
+    localrank = 0
+    if os.getenv('OMPI_COMM_WORLD_LOCAL_RANK'):
+        ## Summit
+        localrank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
+    elif os.getenv('SLURM_LOCALID'):
+        ## CADES
+        localrank = int(os.environ["SLURM_LOCALID"])
+
+    device_name = "cuda:" + str(localrank)
     return device_name, torch.device(device_name)
 
 

--- a/utils/models_setup.py
+++ b/utils/models_setup.py
@@ -32,18 +32,18 @@ def get_device(use_gpu=True, rank_per_model=1):
     print("Using GPU")
     ## We need to ge a local rank if there are multiple GPUs available.
     localrank = 0
-    if os.getenv('OMPI_COMM_WORLD_LOCAL_RANK'):
-        ## Summit
-        localrank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
-    elif os.getenv('SLURM_LOCALID'):
-        ## CADES
-        localrank = int(os.environ["SLURM_LOCALID"])
+    if torch.cuda.device_count()>0:
+        if os.getenv('OMPI_COMM_WORLD_LOCAL_RANK'):
+            ## Summit
+            localrank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
+        elif os.getenv('SLURM_LOCALID'):
+            ## CADES
+            localrank = int(os.environ["SLURM_LOCALID"])
+
+        if localrank >= torch.cuda.device_count():
+            print("WARN: localrank is greater than the available device count - %d %d"%(localrank, torch.cuda.device_count()))
     
     device_name = "cuda:" + str(localrank)
-    if not (localrank < torch.cuda.device_count()):
-        print("WARN: localrank is greater than the available device count - %d %d"%(localrank, torch.cuda.device_count()))
-        device_name = "cuda"
-    print("Set GPU device name: '%s'"%device_name)
 
     return device_name, torch.device(device_name)
 

--- a/utils/models_setup.py
+++ b/utils/models_setup.py
@@ -30,14 +30,15 @@ def get_device(use_gpu=True, rank_per_model=1):
         raise ValueError("Exactly 1 rank per device currently supported")
 
     print("Using GPU")
-    ## We need to ge a local rank to assign one of GPUs per node
+    ## We need to ge a local rank if there are multiple GPUs available.
     localrank = 0
-    if os.getenv('OMPI_COMM_WORLD_LOCAL_RANK'):
-        ## Summit
-        localrank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
-    elif os.getenv('SLURM_LOCALID'):
-        ## CADES
-        localrank = int(os.environ["SLURM_LOCALID"])
+    if torch.cuda.device_count()>1:
+        if os.getenv('OMPI_COMM_WORLD_LOCAL_RANK'):
+            ## Summit
+            localrank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
+        elif os.getenv('SLURM_LOCALID'):
+            ## CADES
+            localrank = int(os.environ["SLURM_LOCALID"])
 
     device_name = "cuda:" + str(localrank)
     return device_name, torch.device(device_name)

--- a/utils/models_setup.py
+++ b/utils/models_setup.py
@@ -32,15 +32,19 @@ def get_device(use_gpu=True, rank_per_model=1):
     print("Using GPU")
     ## We need to ge a local rank if there are multiple GPUs available.
     localrank = 0
-    if torch.cuda.device_count()>1:
-        if os.getenv('OMPI_COMM_WORLD_LOCAL_RANK'):
-            ## Summit
-            localrank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
-        elif os.getenv('SLURM_LOCALID'):
-            ## CADES
-            localrank = int(os.environ["SLURM_LOCALID"])
-
+    if os.getenv('OMPI_COMM_WORLD_LOCAL_RANK'):
+        ## Summit
+        localrank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
+    elif os.getenv('SLURM_LOCALID'):
+        ## CADES
+        localrank = int(os.environ["SLURM_LOCALID"])
+    
     device_name = "cuda:" + str(localrank)
+    if not (localrank < torch.cuda.device_count()):
+        print("WARN: localrank is greater than the available device count - %d %d"%(localrank, torch.cuda.device_count()))
+        device_name = "cuda"
+    print("Set GPU device name: '%s'"%device_name)
+
     return device_name, torch.device(device_name)
 
 

--- a/utils/models_setup.py
+++ b/utils/models_setup.py
@@ -30,7 +30,9 @@ def get_device(use_gpu=True, rank_per_model=1):
         raise ValueError("Exactly 1 rank per device currently supported")
 
     print("Using GPU")
-    device_name = "cuda:" + str(world_rank)
+    ## We try not to specify GPU IDs to be more flexible
+    #device_name = "cuda:" + str(world_rank)
+    device_name = "cuda"
     return device_name, torch.device(device_name)
 
 

--- a/utils/models_setup.py
+++ b/utils/models_setup.py
@@ -33,16 +33,19 @@ def get_device(use_gpu=True, rank_per_model=1):
     ## We need to ge a local rank if there are multiple GPUs available.
     localrank = 0
     if torch.cuda.device_count() > 1:
-        if os.getenv('OMPI_COMM_WORLD_LOCAL_RANK'):
+        if os.getenv("OMPI_COMM_WORLD_LOCAL_RANK"):
             ## Summit
             localrank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
-        elif os.getenv('SLURM_LOCALID'):
+        elif os.getenv("SLURM_LOCALID"):
             ## CADES
             localrank = int(os.environ["SLURM_LOCALID"])
 
         if localrank >= torch.cuda.device_count():
-            print("WARN: localrank is greater than the available device count - %d %d"%(localrank, torch.cuda.device_count()))
-    
+            print(
+                "WARN: localrank is greater than the available device count - %d %d"
+                % (localrank, torch.cuda.device_count())
+            )
+
     device_name = "cuda:" + str(localrank)
 
     return device_name, torch.device(device_name)

--- a/utils/models_setup.py
+++ b/utils/models_setup.py
@@ -32,7 +32,7 @@ def get_device(use_gpu=True, rank_per_model=1):
     print("Using GPU")
     ## We need to ge a local rank if there are multiple GPUs available.
     localrank = 0
-    if torch.cuda.device_count()>0:
+    if torch.cuda.device_count() > 1:
         if os.getenv('OMPI_COMM_WORLD_LOCAL_RANK'):
             ## Summit
             localrank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -18,14 +18,58 @@ from data_utils.dataset_descriptors import (
 )
 from utils.visualizer import Visualizer
 
+import re
+
+def parse_slurm_nodelist(nodelist):
+    """
+    Parse SLURM_NODELIST env string to get list of nodes.
+    Usage example:
+        parse_slurm_nodelist(os.environ["SLURM_NODELIST"])
+    Input examples:
+        "or-condo-g04"
+        "or-condo-g[05,07-08,13]"
+        "or-condo-g[05,07-08,13],or-condo-h[01,12]"
+    """
+    nlist = list()
+    for block, _ in re.findall(r'([\w-]+(\[[\d\-,]+\])*)', nodelist):
+        m = re.match(r'^(?P<prefix>[\w\-]+)\[(?P<group>.*)\]', block)
+        if m is None:
+            ## single node
+            nlist.append(block)
+        else:
+            ## multiple nodes
+            g = m.groups()
+            prefix = g[0]
+            for sub in g[1].split(','):
+                if '-' in sub:
+                    start, end = re.match(r'(\d+)-(\d+)', sub).groups()
+                    fmt = '%%0%dd'%(len(start))
+                    for i in range(int(start), int(end)+1):
+                        node = prefix+fmt%i
+                        nlist.append(node)
+                else:
+                    node = prefix+sub
+                    nlist.append(node)
+
+    return nlist
+
 
 def get_comm_size_and_rank():
-    world_size = 1
+    world_size = None
     world_rank = 0
-    try:
-        world_size = os.environ["OMPI_COMM_WORLD_SIZE"]
-        world_rank = os.environ["OMPI_COMM_WORLD_RANK"]
-    except KeyError:
+
+    if os.getenv('OMPI_COMM_WORLD_SIZE') and os.getenv('OMPI_COMM_WORLD_RANK'):
+        ## Summit
+        world_size = int(os.environ["OMPI_COMM_WORLD_SIZE"])
+        world_rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
+    elif os.getenv('SLURM_NPROCS') and os.getenv('SLURM_PROCID'):
+        ## CADES
+        world_size = int(os.environ["SLURM_NPROCS"])
+        world_rank = int(os.environ["SLURM_PROCID"])
+
+    ## Fall back to default
+    if world_size is None:
+        world_size = 1
         print("DDP has to be initialized within a job - Running in sequential mode")
 
     return int(world_size), int(world_rank)
@@ -40,26 +84,29 @@ def setup_ddp():
     distributed_data_parallelism = False
     world_size, world_rank = get_comm_size_and_rank()
 
-    ## source: https://www.olcf.ornl.gov/wp-content/uploads/2019/12/Scaling-DL-on-Summit.pdf
-    ## The following is Summit specific
-    import subprocess
-    get_master = "echo $(cat {} | sort | uniq | grep -v batch | grep -v login | head -1 )".format(os.environ['LSB_DJOB_HOSTFILE'])
-    master_addr = str(subprocess.check_output(get_master, shell=True))[2:-3]
-    master_port = "23456"
+    ## Default setting
+    master_addr = "127.0.0.1"
+    master_port = "8889"
+
+    if os.getenv('LSB_DJOB_HOSTFILE') is not None:
+        ## source: https://www.olcf.ornl.gov/wp-content/uploads/2019/12/Scaling-DL-on-Summit.pdf
+        ## The following is Summit specific
+        import subprocess
+        get_master = "echo $(cat {} | sort | uniq | grep -v batch | grep -v login | head -1 )".format(os.environ['LSB_DJOB_HOSTFILE'])
+        master_addr = str(subprocess.check_output(get_master, shell=True))[2:-3]
+    elif os.getenv('SLURM_NODELIST') is not None:
+        master_addr = parse_slurm_nodelist(os.environ["SLURM_NODELIST"])[0]
 
     try:
-        world_size = os.environ["OMPI_COMM_WORLD_SIZE"]
-        world_rank = os.environ["OMPI_COMM_WORLD_RANK"]
         os.environ["MASTER_ADDR"] = master_addr
         os.environ["MASTER_PORT"] = master_port
-        os.environ["WORLD_SIZE"] = world_size
-        os.environ["RANK"] = world_rank
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["RANK"] = str(world_rank)
         if not dist.is_initialized():
             dist.init_process_group(
                 backend=backend, rank=int(world_rank), world_size=int(world_size)
             )
         distributed_data_parallelism = True
-
     except KeyError:
         print("DDP has to be initialized within a job - Running in sequential mode")
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -40,8 +40,13 @@ def setup_ddp():
     distributed_data_parallelism = False
     world_size, world_rank = get_comm_size_and_rank()
 
-    master_addr = "127.0.0.1"
-    master_port = "8889"
+    ## source: https://www.olcf.ornl.gov/wp-content/uploads/2019/12/Scaling-DL-on-Summit.pdf
+    ## The following is Summit specific
+    import subprocess
+    get_master = "echo $(cat {} | sort | uniq | grep -v batch | grep -v login | head -1 )".format(os.environ['LSB_DJOB_HOSTFILE'])
+    master_addr = str(subprocess.check_output(get_master, shell=True))[2:-3]
+    master_port = "23456"
+
     try:
         world_size = os.environ["OMPI_COMM_WORLD_SIZE"]
         world_rank = os.environ["OMPI_COMM_WORLD_RANK"]

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -20,6 +20,7 @@ from utils.visualizer import Visualizer
 
 import re
 
+
 def parse_slurm_nodelist(nodelist):
     """
     Parse SLURM_NODELIST env string to get list of nodes.
@@ -31,8 +32,8 @@ def parse_slurm_nodelist(nodelist):
         "or-condo-g[05,07-08,13],or-condo-h[01,12]"
     """
     nlist = list()
-    for block, _ in re.findall(r'([\w-]+(\[[\d\-,]+\])*)', nodelist):
-        m = re.match(r'^(?P<prefix>[\w\-]+)\[(?P<group>.*)\]', block)
+    for block, _ in re.findall(r"([\w-]+(\[[\d\-,]+\])*)", nodelist):
+        m = re.match(r"^(?P<prefix>[\w\-]+)\[(?P<group>.*)\]", block)
         if m is None:
             ## single node
             nlist.append(block)
@@ -40,15 +41,15 @@ def parse_slurm_nodelist(nodelist):
             ## multiple nodes
             g = m.groups()
             prefix = g[0]
-            for sub in g[1].split(','):
-                if '-' in sub:
-                    start, end = re.match(r'(\d+)-(\d+)', sub).groups()
-                    fmt = '%%0%dd'%(len(start))
-                    for i in range(int(start), int(end)+1):
-                        node = prefix+fmt%i
+            for sub in g[1].split(","):
+                if "-" in sub:
+                    start, end = re.match(r"(\d+)-(\d+)", sub).groups()
+                    fmt = "%%0%dd" % (len(start))
+                    for i in range(int(start), int(end) + 1):
+                        node = prefix + fmt % i
                         nlist.append(node)
                 else:
-                    node = prefix+sub
+                    node = prefix + sub
                     nlist.append(node)
 
     return nlist
@@ -58,11 +59,11 @@ def get_comm_size_and_rank():
     world_size = None
     world_rank = 0
 
-    if os.getenv('OMPI_COMM_WORLD_SIZE') and os.getenv('OMPI_COMM_WORLD_RANK'):
+    if os.getenv("OMPI_COMM_WORLD_SIZE") and os.getenv("OMPI_COMM_WORLD_RANK"):
         ## Summit
         world_size = int(os.environ["OMPI_COMM_WORLD_SIZE"])
         world_rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
-    elif os.getenv('SLURM_NPROCS') and os.getenv('SLURM_PROCID'):
+    elif os.getenv("SLURM_NPROCS") and os.getenv("SLURM_PROCID"):
         ## CADES
         world_size = int(os.environ["SLURM_NPROCS"])
         world_rank = int(os.environ["SLURM_PROCID"])
@@ -88,13 +89,16 @@ def setup_ddp():
     master_addr = "127.0.0.1"
     master_port = "8889"
 
-    if os.getenv('LSB_DJOB_HOSTFILE') is not None:
+    if os.getenv("LSB_DJOB_HOSTFILE") is not None:
         ## source: https://www.olcf.ornl.gov/wp-content/uploads/2019/12/Scaling-DL-on-Summit.pdf
         ## The following is Summit specific
         import subprocess
-        get_master = "echo $(cat {} | sort | uniq | grep -v batch | grep -v login | head -1 )".format(os.environ['LSB_DJOB_HOSTFILE'])
+
+        get_master = "echo $(cat {} | sort | uniq | grep -v batch | grep -v login | head -1 )".format(
+            os.environ["LSB_DJOB_HOSTFILE"]
+        )
         master_addr = str(subprocess.check_output(get_master, shell=True))[2:-3]
-    elif os.getenv('SLURM_NODELIST') is not None:
+    elif os.getenv("SLURM_NODELIST") is not None:
         master_addr = parse_slurm_nodelist(os.environ["SLURM_NODELIST"])[0]
 
     try:


### PR DESCRIPTION
Minor fixes for using multiple nodes on Summit:

* To use NCCL, we need to specify master address and port. Followed the instructions from OLCF examples
* Trying to avoid using specific GPU IDs to be flexible.

I tested with the following command line:
```
jsrun -n12 -a1 -g1 -c4 -r6 -b rs --smpiargs="-gpu" python -u run_config_input.py
```

Note: I found `--smpiargs="-gpu" is more useful. After this fix, I don't see any cuda hook error.