### PR TITLE
 Only reinstall dependencies if cache not found

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,10 +31,12 @@ jobs:
           sudo apt-get clean
       - name: Cache pip
         uses: actions/cache@v2
+        id: cache
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('requirements-torchdep.txt') }}
       - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade -r requirements.txt -r requirements-dev.txt


### PR DESCRIPTION
Near duplicate of #17 (issues were previously related to having an empty cache). The same approach now fixes #48 instead

This is the easiest way to actually benefit from the cache - but it will not automatically upgrade packages until we change the requirements files. We should probably set minimum required versions for some packages anyway