### PR TITLE
Fix deprecation warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,6 @@
 norecursedirs = dataset
 python_classes = Pytest
 python_functions = pytest_
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::FutureWarning

--- a/utils/deterministic_graph_data.py
+++ b/utils/deterministic_graph_data.py
@@ -51,9 +51,8 @@ def deterministic_graph_data(
     positions = torch.zeros(number_nodes, 3)
 
     assert (
-        number_neighbors < number_nodes,
-        "Number of neighbors exceeds total number of nodes in the graph",
-    )
+        number_neighbors < number_nodes
+    ), "Number of neighbors exceeds total number of nodes in the graph"
 
     # We assume that the unit cell is Body Center Cubic (BCC)
     count_pos = 0

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -4,7 +4,7 @@ from tqdm import tqdm
 
 import torch
 import torch.distributed as dist
-from torch_geometric.data import DataLoader
+from torch_geometric.loader import DataLoader
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 from data_utils.serialized_dataset_loader import (


### PR DESCRIPTION
Ignore upstream package warnings in pytest, fix torch_geometric module deprecation, and fix broken assertion

Fixes #87 