### PR TITLE
Add edge length

### DIFF
--- a/data_utils/serialized_dataset_loader.py
+++ b/data_utils/serialized_dataset_loader.py
@@ -56,7 +56,7 @@ class SerializedDataLoader:
             _ = pickle.load(f)
             dataset = pickle.load(f)
 
-        edge_index, edge_distances = self.__compute_edges(
+        edge_index, edge_length = self.__compute_edges(
             data=dataset[0],
             radius=config["Architecture"]["radius"],
             max_num_node_neighbours=config["Architecture"]["max_neighbours"],
@@ -64,7 +64,7 @@ class SerializedDataLoader:
 
         for data in dataset:
             data.edge_index = edge_index
-            data.edge_attr = edge_distances
+            data.edge_attr = edge_length
             self.__update_predicted_values(
                 config["Variables_of_interest"]["type"],
                 config["Variables_of_interest"]["output_index"],

--- a/models/Base.py
+++ b/models/Base.py
@@ -124,14 +124,17 @@ class Base(torch.nn.Module):
         return out
 
     def forward(self, data):
-        x, edge_index, batch = (
+        x, edge_index, edge_length, batch = (
             data.x,
             data.edge_index,
+            data.edge_attr,
             data.batch,
         )
         ### encoder part ####
         for conv, batch_norm in zip(self.convs, self.batch_norms):
-            x = F.relu(batch_norm(conv(x=x, edge_index=edge_index)))
+            x = F.relu(
+                batch_norm(conv(x=x, edge_index=edge_index, edge_attr=edge_length))
+            )
         #### multi-head decoder part####
         # shared dense layers for graph level output
         x_graph = global_mean_pool(x, batch)

--- a/models/GINStack.py
+++ b/models/GINStack.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn.functional as F
 import torch.nn as nn
 from torch.nn import ModuleList
-from torch_geometric.nn import GINConv, BatchNorm
+from torch_geometric.nn import GINEConv, BatchNorm
 
 from .Base import Base
 
@@ -30,7 +30,7 @@ class GINStack(Base):
         self.convs = ModuleList()
         self.batch_norms = ModuleList()
         self.convs.append(
-            GINConv(
+            GINEConv(
                 nn.Sequential(
                     nn.Linear(input_dim, self.hidden_dim),
                     nn.ReLU(),
@@ -43,7 +43,7 @@ class GINStack(Base):
 
         self.batch_norms.append(BatchNorm(self.hidden_dim))
         for _ in range(self.num_conv_layers - 1):
-            conv = GINConv(
+            conv = GINEConv(
                 nn.Sequential(
                     nn.Linear(self.hidden_dim, self.hidden_dim),
                     nn.ReLU(),


### PR DESCRIPTION
This is very much WIP. With @pzhanggit 's help I have found:

- Only PNA supports of the 4 models (CGConv does as well)
- GIN has an additional version GINE for edges
- PNA currently breaks because we don't define the `edge_encoder`
- GINE currently breaks because dimensions that don't agree (but I think actually do based on what I've checked)