### PR TITLE
Fixes two errors that are encountered on Summit on 24 GPUs

### DIFF
--- a/hydragnn/run_training.py
+++ b/hydragnn/run_training.py
@@ -162,6 +162,7 @@ def run_training(config_file="./examples/configuration.json"):
     else:
         writer = SummaryWriter("./logs/" + model_with_config_name)
 
+    dist.barrier()
     with open("./logs/" + model_with_config_name + "/config.json", "w") as f:
         json.dump(config, f)
 

--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -16,6 +16,7 @@ import torch
 
 from hydragnn.preprocess.serialized_dataset_loader import SerializedDataLoader
 from hydragnn.postprocess.visualizer import Visualizer
+from hydragnn.postprocess.postprocess import output_denormalize
 from hydragnn.utils.print_utils import print_distributed, iterate_tqdm
 
 


### PR DESCRIPTION
1) Ranks other than 0 were trying to read the log file before it is written by rank 0. I added a barrier for all ranks to wait for rank 0 to finish writing.
2) `output_denormalize` was not recognized. I added the respective `import` statement.